### PR TITLE
Use only one aiohttp.ClientSession as advised in aiohttp documentation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "C:\\Users\\Happy\\AppData\\Local\\Programs\\Python\\Python38\\python.exe"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "C:\\Users\\Happy\\AppData\\Local\\Programs\\Python\\Python38\\python.exe"
+}

--- a/akinator/async_aki/async_akinator.py
+++ b/akinator/async_aki/async_akinator.py
@@ -230,3 +230,10 @@ class Akinator():
             return self.first_guess
         else:
             return raise_connection_error(resp["completion"])
+
+    async def close(self):
+        if self.client_session is not None and self.client_session.closed is False:
+            await self.client_session.close()
+        
+        self.client_session = None # setting it to None either way, so if our client session is closed but our session still exists, we set this to None
+        


### PR DESCRIPTION
Using one aiohttp ClientSession is faster as we do not need to create new client sessions every function call and also allows for more flexibility for default session parameters in the future.